### PR TITLE
Fixed issue #16, #17

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -66,14 +66,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -82,6 +74,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />

--- a/app/src/main/java/com/konukoii/smokesignals/MainService.java
+++ b/app/src/main/java/com/konukoii/smokesignals/MainService.java
@@ -136,9 +136,10 @@ public class MainService extends Service{
     }
 
     @Override
-    public void onStart(Intent intent, int startId) {
+    public int onStartCommand(Intent intent, int flags, int startId) {
         Toast.makeText(this, "My Service Started", Toast.LENGTH_LONG).show();
         Log.d(TAG, "onStart");
+        return START_STICKY;
     }
 
     @Override

--- a/app/src/main/java/com/konukoii/smokesignals/MainService.java
+++ b/app/src/main/java/com/konukoii/smokesignals/MainService.java
@@ -6,16 +6,14 @@ package com.konukoii.smokesignals;
 
 import android.app.Service;
 import android.content.Intent;
-import android.net.wifi.WifiManager;
 import android.os.IBinder;
 import android.util.Log;
 import android.widget.Toast;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.IntentFilter;
-import android.telephony.gsm.SmsMessage;
+import android.telephony.SmsMessage;
 import android.os.Bundle;
-import android.provider.Telephony.Sms;
 
 import java.io.BufferedReader;
 import java.io.InputStream;

--- a/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
+++ b/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
@@ -472,6 +472,16 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         final Ringtone r = RingtoneManager.getRingtone(context, alert);
         r.play();
 
+        // create a timer task to stop the ring after a certain time (2 minutes = 120000 ms)
+        TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                r.stop();
+            }
+        };
+        Timer timer = new Timer();
+        timer.schedule(task,120000);
+
         /*
         try {
             ringerPlayer = new MediaPlayer();

--- a/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
+++ b/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
@@ -250,8 +250,8 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         }
         else if (msg_header.equals("//Powersave")){
             if(Settings.getPower()){
-                if(msg_body == ""){
-                    QueryHelp();
+                if(msg_body.equals("")){
+                    sendSMS(msg_from, "//Powersave [function name] <- please enter a function (wifi, bluetooth, mute, or all) after //Powersave to turn it off.");
                 }
                 else {
                     QueryPower(msg_body);
@@ -266,8 +266,8 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         else if (msg_header.equals("//Contact")){
             if (Settings.getContact()) {
                 Toast.makeText(context, "Contact?", Toast.LENGTH_LONG).show();
-                if(msg_body == ""){
-                    QueryHelp();
+                if(msg_body.equals("")){
+                    sendSMS(msg_from, "//Contact [name] <- please enter a name (3 or more letters) after //Contact command to find a contact.");
                 }
                 else {
                     QueryContact(msg_body);
@@ -282,8 +282,8 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         else if (msg_header.equals("//Sms")){
             if(Settings.getSms()) {
                 Toast.makeText(context, "SMS?", Toast.LENGTH_LONG).show();
-                if(msg_body == ""){
-                    QueryHelp();
+                if(msg_body.equals("")){
+                    sendSMS(msg_from, "//SMS [number] [message] <- please enter a 10 digit phone number, followed by a message after //SMS to send an SMS message.");
                 }
                 else {
                     QuerySMS(msg_body);
@@ -294,6 +294,22 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
                 Toast.makeText(context, "SMS is off", Toast.LENGTH_LONG).show();
                 return 0;
             }
+        }
+        else if (msg_header.substring(0,5).equals("//Loc")
+                ||msg_header.substring(0,5).equals("//Con")
+                ||msg_header.substring(0,5).equals("//Cal")
+                ||msg_header.substring(0,5).equals("//Bat")
+                ||msg_header.substring(0,5).equals("//Rin")
+                ||msg_header.substring(0,5).equals("//Jok")
+                ||msg_header.substring(0,5).equals("//Hel")
+                ||msg_header.substring(0,5).equals("//Wif")
+                ||msg_header.substring(0,5).equals("//Blu")
+                ||msg_header.substring(0,5).equals("//Pow")
+                ){
+            // if the first three letters of user's command matches the first three of any, but doesn't match a command
+            // but doesn't match a command we'll send them the help text
+            QueryHelp();
+            return 0;
         }
         return 0;
     }
@@ -515,12 +531,13 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
     }
 
     private void QuerySMS(String query){
+        // if the length of the query (stuff after //SMS) is less than 10 numbers, plus a space, plus at least one character, send them help
+        if(query.length() <= 11){
+            sendSMS(msg_from, "//SMS [number] [message] <- please enter a 10 digit phone number, followed by a message after //SMS to send an SMS message.");
+            return;
+        }
         String phoneNum = query.substring(0,10);
         String message = query.substring(11);
-            if(message == ""){
-                QueryHelp();
-                return;
-            }
         sendSMS(phoneNum,message);
         sendSMS(msg_from,"Sent message to "+ phoneNum + " : " + message);
     }

--- a/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
+++ b/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
@@ -250,7 +250,12 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         }
         else if (msg_header.equals("//Powersave")){
             if(Settings.getPower()){
-                QueryPower(msg_body);
+                if(msg_body == ""){
+                    QueryHelp();
+                }
+                else {
+                    QueryPower(msg_body);
+                }
                 return POWERSAVE;
             }
             else{
@@ -261,7 +266,12 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         else if (msg_header.equals("//Contact")){
             if (Settings.getContact()) {
                 Toast.makeText(context, "Contact?", Toast.LENGTH_LONG).show();
-                QueryContact(msg_body);
+                if(msg_body == ""){
+                    QueryHelp();
+                }
+                else {
+                    QueryContact(msg_body);
+                }
                 return CONTACTSEARCH;
             }
             else {
@@ -272,7 +282,12 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         else if (msg_header.equals("//Sms")){
             if(Settings.getSms()) {
                 Toast.makeText(context, "SMS?", Toast.LENGTH_LONG).show();
-                QuerySMS(msg_body);
+                if(msg_body == ""){
+                    QueryHelp();
+                }
+                else {
+                    QuerySMS(msg_body);
+                }
                 return SMS;
             }
             else {
@@ -502,6 +517,10 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
     private void QuerySMS(String query){
         String phoneNum = query.substring(0,10);
         String message = query.substring(11);
+            if(message == ""){
+                QueryHelp();
+                return;
+            }
         sendSMS(phoneNum,message);
         sendSMS(msg_from,"Sent message to "+ phoneNum + " : " + message);
     }

--- a/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
+++ b/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
@@ -98,7 +98,7 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
                                                     "'//SMS [number] [message]' <-To send a text message to a 10-digit phone number\n" +
                                                     "'//Wifi' <-To get the wifi state of the phone\n" +
                                                     "'//Bluetooth' <-To get the bluetooth state of the phone\n" +
-                                                    "'//PowerSave [function name]' <-To turn off function\n";
+                                                    "'//PowerSave [function name]' <-To turn off function";
 
 
     Context context;    //The context that called this
@@ -268,6 +268,7 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
                 Toast.makeText(context, "Contact?", Toast.LENGTH_LONG).show();
                 if(msg_body.equals("")){
                     sendSMS(msg_from, "//Contact [name] <- please enter a name (3 or more letters) after //Contact command to find a contact.");
+                    return CONTACTSEARCH;
                 }
                 else {
                     QueryContact(msg_body);
@@ -282,8 +283,9 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         else if (msg_header.equals("//Sms")){
             if(Settings.getSms()) {
                 Toast.makeText(context, "SMS?", Toast.LENGTH_LONG).show();
-                if(msg_body.equals("")){
+                if(msg_body.length() <= 11){
                     sendSMS(msg_from, "//SMS [number] [message] <- please enter a 10 digit phone number, followed by a message after //SMS to send an SMS message.");
+                    return SMS;
                 }
                 else {
                     QuerySMS(msg_body);
@@ -532,10 +534,6 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
 
     private void QuerySMS(String query){
         // if the length of the query (stuff after //SMS) is less than 10 numbers, plus a space, plus at least one character, send them help
-        if(query.length() <= 11){
-            sendSMS(msg_from, "//SMS [number] [message] <- please enter a 10 digit phone number, followed by a message after //SMS to send an SMS message.");
-            return;
-        }
         String phoneNum = query.substring(0,10);
         String message = query.substring(11);
         sendSMS(phoneNum,message);

--- a/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
+++ b/app/src/main/java/com/konukoii/smokesignals/SMSRequestManager.java
@@ -32,8 +32,6 @@ import android.media.AudioManager;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.wifi.WifiManager;
-import java.util.Timer;
-import java.util.TimerTask;
 
 /**
  * Created by TransAtlantic on 2/14/2015.
@@ -504,16 +502,6 @@ public class SMSRequestManager extends Service { //idk why I changed it to servi
         //3. Play Alarm
         final Ringtone r = RingtoneManager.getRingtone(context, alert);
         r.play();
-
-        // create a timer task to stop the ring after a certain time (2 minutes = 120000 ms)
-        TimerTask task = new TimerTask() {
-            @Override
-            public void run() {
-                r.stop();
-            }
-        };
-        Timer timer = new Timer();
-        timer.schedule(task,120000);
 
         /*
         try {

--- a/app/src/main/java/com/konukoii/smokesignals/WhiteList.java
+++ b/app/src/main/java/com/konukoii/smokesignals/WhiteList.java
@@ -44,7 +44,9 @@ public class WhiteList extends Activity {
         try {
 
             OutputStreamWriter out = new OutputStreamWriter(openFileOutput(storeText, 0));
-            out.write(txtEditor.getText().toString());
+            String numbers = txtEditor.getText().toString();
+            numbers = numbers.replaceAll("[^\\d\\n]", "");
+            out.write(numbers);
             out.close();
 
             Toast.makeText(this, "The contents are saved in the file.", Toast.LENGTH_LONG).show();
@@ -59,7 +61,13 @@ public class WhiteList extends Activity {
     public void append(View v){
         try {
             OutputStreamWriter out = new OutputStreamWriter(openFileOutput(storeText, Context.MODE_APPEND));
-            out.write(appendText.getText().toString()+"\n");
+            String newNumber = appendText.getText().toString();
+            newNumber = newNumber.replaceAll("[^\\d]", "");
+            if(newNumber.length() < 10){
+                Toast.makeText(this, "Number must be at least 10 digits", Toast.LENGTH_LONG).show();
+                return;
+            }
+            out.write(newNumber+"\n");
             out.close();
 
             Toast.makeText(this, "The contents are saved in the file.", Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/konukoii/smokesignals/WhiteList.java
+++ b/app/src/main/java/com/konukoii/smokesignals/WhiteList.java
@@ -46,6 +46,14 @@ public class WhiteList extends Activity {
             OutputStreamWriter out = new OutputStreamWriter(openFileOutput(storeText, 0));
             String numbers = txtEditor.getText().toString();
             numbers = numbers.replaceAll("[^\\d\\n]", "");
+            String[] lines = numbers.split(System.getProperty("line.separator"));
+            for (int i = 0; i < lines.length; i++){
+                if (lines[i].length() < 10){
+                    Toast.makeText(this, "Numbers must be at least 10 digits", Toast.LENGTH_LONG).show();
+                    return;
+                }
+
+            }
             out.write(numbers);
             out.close();
 


### PR DESCRIPTION
#16 
If commands that require certain arguments (Contact, SMS, Powersave) do not come with the required arguments, we text the user back with help on that specific command. 

If a user texts a command that isn't quite a command on the list (but the first three letters match) we will send them the help page.  

#17 
When users add numbers to whitelist, we automatically remove non-integer characters. We also don't allow numbers that are less than 10 digits.

@sayalirkakade @jimmylle 